### PR TITLE
Work around OPERATION_BUSY issue

### DIFF
--- a/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MainActivity.java
+++ b/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MainActivity.java
@@ -16,11 +16,6 @@
 
 package com.here.android.example.map.downloader;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.here.android.mpa.odml.MapLoader;
-
 import android.Manifest;
 import android.app.ListActivity;
 import android.content.pm.PackageManager;
@@ -31,16 +26,17 @@ import android.view.View;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Main activity which launches the map list view and handles Android run-time requesting
  * permission.
  */
 
 public class MainActivity extends ListActivity {
-
     private final static int REQUEST_CODE_ASK_PERMISSIONS = 1;
     private MapListView m_mapListView;
-    private MapLoader m_mapLoader;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -54,8 +50,7 @@ public class MainActivity extends ListActivity {
      * needs when the app is running.
      */
     private void requestPermissions() {
-
-        final List<String> requiredSDKPermissions = new ArrayList<String>();
+        final List<String> requiredSDKPermissions = new ArrayList<>();
         requiredSDKPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
         requiredSDKPermissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         requiredSDKPermissions.add(Manifest.permission.INTERNET);
@@ -75,7 +70,7 @@ public class MainActivity extends ListActivity {
                 for (int index = 0; index < permissions.length; index++) {
                     if (grantResults[index] != PackageManager.PERMISSION_GRANTED) {
 
-                        /**
+                        /*
                          * If the user turned down the permission request in the past and chose the
                          * Don't ask again option in the permission request system dialog.
                          */
@@ -93,7 +88,7 @@ public class MainActivity extends ListActivity {
                     }
                 }
 
-                /**
+                /*
                  * All permission requests are being handled.Create map fragment view.Please note
                  * the HERE SDK requires all permissions defined above to operate properly.
                  */

--- a/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MapListAdapter.java
+++ b/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MapListAdapter.java
@@ -16,10 +16,6 @@
 
 package com.here.android.example.map.downloader;
 
-import java.util.List;
-
-import com.here.android.mpa.odml.MapPackage;
-
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,10 +23,14 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
-public class MapListAdapter extends ArrayAdapter<MapPackage> {
+import com.here.android.mpa.odml.MapPackage;
+
+import java.util.List;
+
+class MapListAdapter extends ArrayAdapter<MapPackage> {
     private List<MapPackage> m_list;
 
-    public MapListAdapter(Context context, int resource, List<MapPackage> results) {
+    MapListAdapter(Context context, int resource, List<MapPackage> results) {
         super(context, resource, results);
         m_list = results;
     }
@@ -68,5 +68,4 @@ public class MapListAdapter extends ArrayAdapter<MapPackage> {
         tv.setText(String.valueOf(mapPackage.getSize()) + "KB");
         return convertView;
     }
-
 }

--- a/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MapListView.java
+++ b/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MapListView.java
@@ -157,6 +157,9 @@ class MapListView {
             if (resultCode == MapLoader.ResultCode.OPERATION_SUCCESSFUL) {
                 List<MapPackage> children = rootMapPackage.getChildren();
                 refreshListView(new ArrayList<>(children));
+            } else if (resultCode == MapLoader.ResultCode.OPERATION_BUSY) {
+                // The map loader is still busy, just try again.
+                m_mapLoader.getMapPackages();
             }
         }
 
@@ -178,6 +181,9 @@ class MapListView {
                     Toast.makeText(m_activity, "Current map version: " + current + " is the latest",
                             Toast.LENGTH_SHORT).show();
                 }
+            } else if (resultCode == MapLoader.ResultCode.OPERATION_BUSY) {
+                // The map loader is still busy, just try again.
+                m_mapLoader.checkForMapDataUpdate();
             }
         }
 

--- a/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MapListView.java
+++ b/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MapListView.java
@@ -16,14 +16,6 @@
 
 package com.here.android.example.map.downloader;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.here.android.mpa.common.MapEngine;
-import com.here.android.mpa.common.OnEngineInitListener;
-import com.here.android.mpa.odml.MapLoader;
-import com.here.android.mpa.odml.MapPackage;
-
 import android.app.ListActivity;
 import android.view.View;
 import android.widget.Button;
@@ -31,10 +23,16 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-public class MapListView {
+import com.here.android.mpa.common.MapEngine;
+import com.here.android.mpa.common.OnEngineInitListener;
+import com.here.android.mpa.odml.MapLoader;
+import com.here.android.mpa.odml.MapPackage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class MapListView {
     private ListActivity m_activity;
-    private Button m_cancelButton;
-    private Button m_mapUpdateButton;
     private TextView m_progressTextView;
     private MapLoader m_mapLoader;
     private MapListAdapter m_listAdapter;
@@ -42,7 +40,7 @@ public class MapListView {
                                                      // package list currently being displayed on
                                                      // screen
 
-    public MapListView(ListActivity activity) {
+    MapListView(ListActivity activity) {
         m_activity = activity;
         initMapEngine();
     }
@@ -63,16 +61,16 @@ public class MapListView {
     }
 
     private void initUIElements() {
-        m_cancelButton = (Button) m_activity.findViewById(R.id.cancelBtn);
-        m_cancelButton.setOnClickListener(new View.OnClickListener() {
+        Button cancelButton = (Button) m_activity.findViewById(R.id.cancelBtn);
+        cancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 m_mapLoader.cancelCurrentOperation();
             }
         });
         m_progressTextView = (TextView) m_activity.findViewById(R.id.progressTextView);
-        m_mapUpdateButton = (Button) m_activity.findViewById(R.id.mapUpdateBtn);
-        m_mapUpdateButton.setOnClickListener(new View.OnClickListener() {
+        Button mapUpdateButton = (Button) m_activity.findViewById(R.id.mapUpdateBtn);
+        mapUpdateButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 /*
@@ -98,7 +96,7 @@ public class MapListView {
     }
 
     // Handles the click action on map list item.
-    public void onListItemClicked(ListView l, View v, int position, long id) {
+    void onListItemClicked(ListView l, View v, int position, long id) {
         MapPackage clickedMapPackage = m_currentMapPackageList.get(position);
         List<MapPackage> children = clickedMapPackage.getChildren();
         if (children.size() > 0) {
@@ -146,13 +144,11 @@ public class MapListView {
 
         @Override
         public void onInstallationSize(long l, long l1) {
-
         }
 
         @Override
         public void onGetMapPackagesComplete(MapPackage rootMapPackage,
                 MapLoader.ResultCode resultCode) {
-
             /*
              * Please note that to get the latest MapPackage status, the application should always
              * use the rootMapPackage that being returned here. The same applies to other listener
@@ -190,9 +186,8 @@ public class MapListView {
                 MapLoader.ResultCode resultCode) {
             if (resultCode == MapLoader.ResultCode.OPERATION_SUCCESSFUL) {
                 Toast.makeText(m_activity, "Map update is completed", Toast.LENGTH_SHORT).show();
-                refreshListView(new ArrayList<MapPackage>(rootMapPackage.getChildren()));
+                refreshListView(new ArrayList<>(rootMapPackage.getChildren()));
             }
-
         }
 
         @Override


### PR DESCRIPTION
When a map download was started and the app gets (hard) killed, the MapLoader ends up in OPERATION_BUSY state during the next app invocation after MapLoader.getMapPackages(). The workaround is to call the method again.