### PR TITLE
Avoid MapService intent filter clash

### DIFF
--- a/geocoder-and-reverse-geocoder-android/app/src/main/AndroidManifest.xml
+++ b/geocoder-and-reverse-geocoder-android/app/src/main/AndroidManifest.xml
@@ -36,10 +36,10 @@
         <service
             android:name="com.here.android.mpa.service.MapService"
             android:label="HereMapService"
-            android:process="global.Here.Map.Service.v2"
-            android:exported="true">
+            android:process="global.Here.Map.Service.v2">
             <intent-filter>
-                <action android:name="com.here.android.mpa.service.MapService"></action>
+                <!-- When using MapSettings.setIsolatedDiskCacheRootPath(...) make sure to use this value: -->
+                <action android:name="com.here.android.example.geocoding.MapService" />
             </intent-filter>
         </service>
     </application>

--- a/map-downloader-android/app/src/main/AndroidManifest.xml
+++ b/map-downloader-android/app/src/main/AndroidManifest.xml
@@ -38,10 +38,10 @@
         <service
             android:name="com.here.android.mpa.service.MapService"
             android:label="HereMapService"
-            android:process="global.Here.Map.Service.v2"
-            android:exported="true">
+            android:process="global.Here.Map.Service.v2">
             <intent-filter>
-                <action android:name="com.here.android.mpa.service.MapService"></action>
+                <!-- When using MapSettings.setIsolatedDiskCacheRootPath(...) make sure to use this value: -->
+                <action android:name="com.here.android.example.map.downloader.MapService" />
             </intent-filter>
         </service>
     </application>


### PR DESCRIPTION
The intent filter action shouldn't be the same as the MapService class
name (with package). This will fail silently when using
MapSettings.setIsolatedDiskCacheRootPath.

Also don't export the service by default. Otherwise multiple apps
running on the same phone will collide there or end up in weird
behavior. Sharing the service only works reliably when one apps declares
it and others just use it (and don't declare in their manifests).