### PR TITLE
Removed usage of deprecated API

### DIFF
--- a/geocoder-and-reverse-geocoder-android/app/src/main/java/com/here/android/example/geocoding/MainView.java
+++ b/geocoder-and-reverse-geocoder-android/app/src/main/java/com/here/android/example/geocoding/MainView.java
@@ -18,6 +18,7 @@ package com.here.android.example.geocoding;
 
 import java.util.List;
 
+import com.here.android.mpa.common.ApplicationContext;
 import com.here.android.mpa.common.GeoCoordinate;
 import com.here.android.mpa.common.MapEngine;
 import com.here.android.mpa.common.OnEngineInitListener;
@@ -52,7 +53,8 @@ public class MainView {
          * services that HERE Android SDK provides, the MapEngine must be initialized as the
          * prerequisite.
          */
-        MapEngine.getInstance().init(m_activity, new OnEngineInitListener() {
+        ApplicationContext context = new ApplicationContext(m_activity);
+        MapEngine.getInstance().init(context, new OnEngineInitListener() {
             @Override
             public void onEngineInitializationCompleted(Error error) {
                 Toast.makeText(m_activity, "Map Engine initialized with error code:" + error,

--- a/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MapListView.java
+++ b/map-downloader-android/app/src/main/java/com/here/android/example/map/downloader/MapListView.java
@@ -23,6 +23,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.here.android.mpa.common.ApplicationContext;
 import com.here.android.mpa.common.MapEngine;
 import com.here.android.mpa.common.OnEngineInitListener;
 import com.here.android.mpa.odml.MapLoader;
@@ -46,7 +47,8 @@ class MapListView {
     }
 
     private void initMapEngine() {
-        MapEngine.getInstance().init(m_activity, new OnEngineInitListener() {
+        ApplicationContext context = new ApplicationContext(m_activity);
+        MapEngine.getInstance().init(context, new OnEngineInitListener() {
             @Override
             public void onEngineInitializationCompleted(Error error) {
                 if (error == Error.NONE) {


### PR DESCRIPTION
MapEngine init() method that was used before are now deprecated. Replaced usage of this method with new one.