### PR TITLE
Update CI configuration

### DIFF
--- a/.ci/preInstall.sh
+++ b/.ci/preInstall.sh
@@ -3,7 +3,7 @@
 # Download and extract the HERE SDK.
 wget "$HERE_SDK_URL" -q -O 'HERE_SDK.zip'
 unzip -j -d 'HERE_SDK' -o 'HERE_SDK.zip'
-unzip -j 'HERE_SDK/HERE-sdk.zip' 'HERE-sdk/HERE-sdk/libs/HERE-sdk.aar' -d 'HERE_SDK'
+unzip -j 'HERE_SDK/HERE-sdk.zip' 'HERE-sdk/libs/HERE-sdk.aar' -d 'HERE_SDK'
 rm 'HERE_SDK.zip'
 
 # Find paths that contain an app module

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
 
-env:
-  global:
-  - secure: "Mcj+GC/b/FxV4Msmbr3UgodSj1ZGBpRCw+Iqb2YaYV52PPUCtx9AeLCkZPJo677+9xqQ9zromBvBttD47IJHG1UT9MS3lI1e3XnjwSHiG0OHwcaPXItYXsDmJslBZW52T2g2yQ1ENpgXL3tLS5RqJi1gaKq1/HbxzsLRWolmwm3TlgqHc4is7yPRI/Szh/utm2RLg6yHwZPHcXe7y5yioYODzarB//7l9Q6af9DnsIbNF3z/KVTGx6HbaAZ/9GNPUdUBCmi/vl2DmEfZBN8WiBr2CSn/Z/ogTD8w1mNKmMKxZSzJsAgw4OhrjHnLdk5OraBXsq5cLCsJg8btGE2xp2qPVqbSyzkTFTHQYeFrHMrZnQ+pc0EIFzEkUVsdk1ptCrxov2TfbFLpBk7xP6VSDNM+A5+MmBDqooU4AJ4KRzd7WgpJxFff0XLLDiDzJMWqr8s+KHMktrOmY9DlFJsuSkPgIdqWiZVf3LjJjjCRxG0oW0D9aOPfGABPlsmK29shO/EVQvXnUBgYnt7zxEpK7oBBNO/2/1ZTci2AEh870Rh3zpjQwrApg1HKGDmDD2/c/4O1YDz41mdmUlyDhTCBBPoiuahnQ7uFUyhBprZVI83H6qRPoPAHupPixSA1x43kEcM6ETZOtBIPXdg/67lhmYvp8fB11aFaCkjMifslx28="
-
 install:
   - echo $ANDROID_HOME
   - mkdir -p $ANDROID_HOME/licenses


### PR DESCRIPTION
Now HERE_SDK_URL is stored in the Travis settings. This should allow external PRs to run CI. In addition, the examples now use the latest SDK (version 3.3.1.237). Since the folder structure of the zip file is now slightly different, the path to get the aar file is updated.