### PR TITLE
Request for app permissions simplified

### DIFF
--- a/map-rendering/app/src/main/java/com/here/android/example/map/basic/MainActivity.java
+++ b/map-rendering/app/src/main/java/com/here/android/example/map/basic/MainActivity.java
@@ -16,7 +16,7 @@
 
 package com.here.android.example.map.basic;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import android.Manifest;
@@ -24,6 +24,7 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
 
@@ -49,17 +50,47 @@ public class MainActivity extends AppCompatActivity {
      */
     private void requestPermissions() {
 
-        final List<String> requiredSDKPermissions = new ArrayList<String>();
-        requiredSDKPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
-        requiredSDKPermissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        requiredSDKPermissions.add(Manifest.permission.INTERNET);
-        requiredSDKPermissions.add(Manifest.permission.ACCESS_WIFI_STATE);
-        requiredSDKPermissions.add(Manifest.permission.ACCESS_NETWORK_STATE);
+        List<String> permissionList = Arrays.asList(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                Manifest.permission.INTERNET,
+                Manifest.permission.ACCESS_WIFI_STATE,
+                Manifest.permission.ACCESS_NETWORK_STATE);
 
-        ActivityCompat.requestPermissions(this,
-                requiredSDKPermissions.toArray(new String[requiredSDKPermissions.size()]),
-                REQUEST_CODE_ASK_PERMISSIONS);
+        // check list of permissions
+        Boolean isPermissionsGranted = true;
+        for (String permission : permissionList) {
+            if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
+                isPermissionsGranted = false;
+                break;
+            }
+        }
+
+        // return if all permissions already granted
+        if (isPermissionsGranted) {
+            createMapFragmentView();
+            return;
+        }
+
+        // request permissions
+        if (android.os.Build.VERSION.SDK_INT >= 23){
+            ActivityCompat.requestPermissions(this,
+                    permissionList.toArray(new String[permissionList.size()]),
+                    REQUEST_CODE_ASK_PERMISSIONS);
+
+        }
+
     }
+
+
+    /**
+     * Create map fragment view.
+     * !!! Please note: the HERE SDK requires all permissions defined above to operate properly. !!!
+     */
+    void createMapFragmentView() {
+        m_mapFragmentView = new MapFragmentView(this);
+    }
+
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
@@ -87,11 +118,10 @@ public class MainActivity extends AppCompatActivity {
                     }
                 }
 
-                /**
-                 * All permission requests are being handled.Create map fragment view.Please note
-                 * the HERE SDK requires all permissions defined above to operate properly.
+                /*
+                 * All permission requests are being handled. Create map fragment view.
                  */
-                m_mapFragmentView = new MapFragmentView(this);
+                createMapFragmentView();
                 break;
             }
             default:

--- a/map-rendering/app/src/main/java/com/here/android/example/map/basic/MainActivity.java
+++ b/map-rendering/app/src/main/java/com/here/android/example/map/basic/MainActivity.java
@@ -16,9 +16,6 @@
 
 package com.here.android.example.map.basic;
 
-import java.util.Arrays;
-import java.util.List;
-
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -50,16 +47,16 @@ public class MainActivity extends AppCompatActivity {
      */
     private void requestPermissions() {
 
-        List<String> permissionList = Arrays.asList(
+        String[] RUNTIME_PERMISSIONS = {
                 Manifest.permission.ACCESS_FINE_LOCATION,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE,
                 Manifest.permission.INTERNET,
                 Manifest.permission.ACCESS_WIFI_STATE,
-                Manifest.permission.ACCESS_NETWORK_STATE);
+                Manifest.permission.ACCESS_NETWORK_STATE};
 
         // check list of permissions
-        Boolean isPermissionsGranted = true;
-        for (String permission : permissionList) {
+        boolean isPermissionsGranted = true;
+        for (String permission : RUNTIME_PERMISSIONS) {
             if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
                 isPermissionsGranted = false;
                 break;
@@ -75,7 +72,7 @@ public class MainActivity extends AppCompatActivity {
         // request permissions
         if (android.os.Build.VERSION.SDK_INT >= 23){
             ActivityCompat.requestPermissions(this,
-                    permissionList.toArray(new String[permissionList.size()]),
+                    RUNTIME_PERMISSIONS,
                     REQUEST_CODE_ASK_PERMISSIONS);
 
         }


### PR DESCRIPTION
The app requests for permissions in `onCreate()` which causes that the permission request dialog appears at each start of the app (on some devices). This pull-request overcomes this issue by checking whether the permission are already granted and only requests them if necessary.

This fixes just the example **map-rendering-android**.

- `requestPermission()` only request permission if they are not granted yet
- introduced function `createMapFragmentView()`
