### PR TITLE
Do not export MapService for other apps.

### DIFF
--- a/positioning-venues-and-logging/app/src/main/AndroidManifest.xml
+++ b/positioning-venues-and-logging/app/src/main/AndroidManifest.xml
@@ -45,18 +45,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <!--
-            Embed the HERE Map Service.
-            For more information, see the HERE SDK Developer's Guide
-        -->
+        <!--Developers should always provide custom values for each of {YOUR_LABEL_NAME} and {YOUR_INTENT_NAME}.
+        Do not reuse HERE SDK defaults.-->
+        <meta-data
+            android:name="INTENT_NAME"
+            android:value="{YOUR_INTENT_NAME}" />
         <service
             android:name="com.here.android.mpa.service.MapService"
-            android:label="HereMapService"
-            android:process="global.Here.Map.Service.v3"
-            android:exported="true" >
+            android:label="{YOUR_LABEL_NAME}"
+            android:exported="false">
             <intent-filter>
-                <action android:name="com.here.android.mpa.service.MapService.v3" >
-                </action>
+                <action android:name="{YOUR_INTENT_NAME}"></action>
             </intent-filter>
         </service>
         <!--

--- a/positioning-venues-and-logging/app/src/main/java/com/here/android/example/venuesandlogging/BasicVenueActivity.java
+++ b/positioning-venues-and-logging/app/src/main/java/com/here/android/example/venuesandlogging/BasicVenueActivity.java
@@ -18,13 +18,15 @@ package com.here.android.example.venuesandlogging;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.PointF;
+import android.os.Bundle;
+import android.os.Environment;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -60,6 +62,7 @@ import com.here.android.mpa.venues3d.VenueService.VenueServiceListener;
 import com.here.android.positioning.DiagnosticsListener;
 import com.here.android.positioning.StatusListener;
 
+import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.Locale;
@@ -900,6 +903,26 @@ public class BasicVenueActivity extends AppCompatActivity
         venueMapFragment = getMapFragment();
         mLocationInfo = (TextView) findViewById(R.id.textViewLocationInfo);
 
+        // Set path of isolated disk cache
+        String diskCacheRoot = Environment.getExternalStorageDirectory().getPath()
+                + File.separator + ".isolated-here-maps";
+        // Retrieve intent name from manifest
+        String intentName = "";
+        try {
+            ApplicationInfo ai = getPackageManager().getApplicationInfo(getPackageName(),
+                    PackageManager.GET_META_DATA);
+            Bundle bundle = ai.metaData;
+            intentName = bundle.getString("INTENT_NAME");
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(TAG, "Failed to find intent name, NameNotFound: " + e.getMessage());
+        }
+        boolean success = com.here.android.mpa.common.MapSettings.setIsolatedDiskCacheRootPath(
+                diskCacheRoot, intentName);
+        if (!success) {
+            Toast.makeText(mActivity, "Operation 'setIsolatedDiskCacheRootPath' was not successful",
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
 
         venueMapFragment.init(new OnEngineInitListener() {
             @Override

--- a/speed-limit-watcher/app/src/main/AndroidManifest.xml
+++ b/speed-limit-watcher/app/src/main/AndroidManifest.xml
@@ -21,17 +21,19 @@
         <meta-data android:name="com.here.android.maps.apptoken" android:value="{SAMPLE_APP_CODE}"/>
         <meta-data android:name="com.here.android.maps.license.key" android:value="{SAMPLE_LICENSE}"/>
 
+        <!--Developers should always provide custom values for each of {YOUR_LABEL_NAME} and {YOUR_INTENT_NAME}.
+        Do not reuse HERE SDK defaults.-->
+        <meta-data
+            android:name="INTENT_NAME"
+            android:value="{YOUR_INTENT_NAME}" />
         <service
             android:name="com.here.android.mpa.service.MapService"
-            android:label="HereMapService"
-            android:process="global.Here.Map.Service.v3"
-            android:exported="true" >
+            android:label="{YOUR_LABEL_NAME}"
+            android:exported="false">
             <intent-filter>
-                <action android:name="com.here.android.mpa.service.MapService.v3" >
-                </action>
+                <action android:name="{YOUR_INTENT_NAME}"></action>
             </intent-filter>
         </service>
-
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/speed-limit-watcher/app/src/main/java/com/here/example/speedlimit/MainActivity.java
+++ b/speed-limit-watcher/app/src/main/java/com/here/example/speedlimit/MainActivity.java
@@ -2,13 +2,15 @@ package com.here.example.speedlimit;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
-
+import android.os.Environment;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.here.android.mpa.common.ApplicationContext;
@@ -17,6 +19,7 @@ import com.here.android.mpa.common.OnEngineInitListener;
 import com.here.android.mpa.common.PositioningManager;
 import com.here.android.mpa.guidance.NavigationManager;
 
+import java.io.File;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -46,8 +49,29 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void initSDK() {
-        ApplicationContext appContext = new ApplicationContext(this);
+        // Set path of isolated disk cache
+        String diskCacheRoot = Environment.getExternalStorageDirectory().getPath()
+                + File.separator + ".isolated-here-maps";
+        // Retrieve intent name from manifest
+        String intentName = "";
+        try {
+            ApplicationInfo ai = getPackageManager().getApplicationInfo(getPackageName(),
+                    PackageManager.GET_META_DATA);
+            Bundle bundle = ai.metaData;
+            intentName = bundle.getString("INTENT_NAME");
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e("MainActivity",
+                    "Failed to find intent name, NameNotFound: " + e.getMessage());
+        }
+        boolean success = com.here.android.mpa.common.MapSettings.setIsolatedDiskCacheRootPath(
+                diskCacheRoot, intentName);
+        if (!success) {
+            Toast.makeText(this, "Operation 'setIsolatedDiskCacheRootPath' was not successful",
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
 
+        ApplicationContext appContext = new ApplicationContext(this);
         MapEngine.getInstance().init(appContext, new OnEngineInitListener() {
             @Override
             public void onEngineInitializationCompleted(Error error) {
@@ -58,7 +82,8 @@ public class MainActivity extends AppCompatActivity {
                     activateSpeedLimitFragment();
 
                 } else {
-                    //handle error here
+                    Log.e("MainActivity", " init error: " + error + ", " + error.getDetails(),
+                            error.getThrowable());
                 }
             }
         });


### PR DESCRIPTION
`MapService` should be only exported and used by other apps if it is running on Android 7 or below. Starting from Android 8 it is recommended not to export service as it will not be started if the app is in background, so client's `MapEngine` initialization callback `onEngineInitializationCompleted(Error error)` will return error(provided app tries to use external `MapService`).