### PR TITLE
Android 9 network security change

### DIFF
--- a/positioning-venues-and-logging/app/src/main/AndroidManifest.xml
+++ b/positioning-venues-and-logging/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/positioning-venues-and-logging/app/src/main/res/xml/network_security_config.xml
+++ b/positioning-venues-and-logging/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">radiomap.vcdn.pos.here.com</domain>
+    </domain-config>
+</network-security-config>

--- a/positioning/app/src/main/AndroidManifest.xml
+++ b/positioning/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/AppTheme">
 
         <activity android:label="@string/app_name" android:name=".BasicPositioningActivity">

--- a/positioning/app/src/main/res/xml/network_security_config.xml
+++ b/positioning/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">radiomap.vcdn.pos.here.com</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
Added network configuration XML and updated AndroidManifest.xml to use them. This change is needed for Android 9, which does not allow unencrypted HTTP connections without security exception. In HERE positioning radio map tiles are downloaded using HTTP because the payload (tiles) are encrypted.